### PR TITLE
Jdevera remote mon

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ chrony will be configured to:
 > be reported using the clients command in chronyc. This option also effectively disables server support
 > for the NTP interleaved mode.
 
+### Remote monitoring
+
+If you'd like to enable remote monitoring, you can pass the environment variable `ALLOW_REMOTE_MON` set to
+`true` to the container. This will let you run `chronyc` commands from another host.
+
+You can use this to check the status of the NTP server without the need to run docker commands.
 
 ## Logging
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -71,6 +71,17 @@ for N in $NTP_SERVERS; do
   fi
 done
 
+# Remote access to the chrony server
+if [ "${ALLOW_REMOTE_MON:-false}" = true ]; then
+  {
+    echo
+    echo "# allow remote monitoring"
+    echo "cmdallow all"
+    echo "bindcmdaddress 0.0.0.0"
+    echo "bindcmdaddress ::"
+  } >> ${CHRONY_CONF_FILE}
+fi
+
 # final bits for the config file
 {
   echo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
 #      - TZ=America/Vancouver
 #      - NOCLIENTLOG=true
 #      - ENABLE_NTS=true
+#      - ALLOW_REMOTE_MON=true

--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,7 @@ function start_container() {
 	      --env=ENABLE_NTS=${ENABLE_NTS}       \
 	      --env=NOCLIENTLOG=${NOCLIENTLOG}     \
               --env=LOG_LEVEL=${LOG_LEVEL}         \
+              --env=ALLOW_REMOTE_MON=${ALLOW_REMOTE_MON}  \
               --read-only=true                     \
               --tmpfs=/etc/chrony:rw,mode=1750     \
               --tmpfs=/run/chrony:rw,mode=1750     \

--- a/vars
+++ b/vars
@@ -4,7 +4,7 @@
 # of these to be appropriate for your environment.
 #
 
-IMAGE_NAME="cturra/ntp"
+IMAGE_NAME="e1342/ntp"
 CONTAINER_NAME="ntp"
 
 # (optional) define ntp server(s) to use
@@ -26,3 +26,6 @@ LOG_LEVEL=0
 
 # (optional) additional docker run options you may want
 DOCKER_OPTS=""
+
+# (optional) allow remote access to chronyd
+ALLOW_REMOTE_MON=false


### PR DESCRIPTION
Implement https://github.com/cturra/docker-ntp/pull/76

[jdevera](https://github.com/jdevera) wants to merge 1 commit into [cturra:main](https://github.com/cturra/docker-ntp/tree/main) from [jdevera:remote_mon](https://github.com/jdevera/docker-ntp/tree/remote_mon)

https://github.com/cturra/docker-ntp/pull/76#issue-2427886014


Setting the ALLOW_REMOTE_MON to true in the container will enable the server to receive chronyc commands from other hosts, using the -h $host option.

This can be useful in docker compose scenarios where a second container can be used to provide the outside world with statistics about the running NTP server without this second container needing to run docker commands.

In my case, I am launching two containers from a docker compose, and in the second container I am exposing an HTTP API that will in turn call chronyc commands (with -h ntp and return their results. I thought it could be a useful contribution.
